### PR TITLE
Separate error values into array for SyncRead function

### DIFF
--- a/example/read/main.go
+++ b/example/read/main.go
@@ -33,6 +33,9 @@ func main() {
 		"Random.UInt2",
 		"Random.UInt4",
 		"Random.UInt8",
+		"Read Error.UInt4",
+		// Errors on purpose to show error handling
+		"Write Only.UInt4",
 		"Bucket Brigade.Real4",
 	}
 	server, err := opcda.Connect(progID, host)
@@ -64,20 +67,25 @@ func main() {
 	for i, item := range itemList {
 		serverHandles[i] = item.GetServerHandle()
 	}
-	status, err := group.SyncRead(opcda.OPC_DS_CACHE, serverHandles)
+	status, resultErrs, err := group.SyncRead(opcda.OPC_DS_CACHE, serverHandles)
 	if err != nil {
 		log.Fatalf("sync read failed: %s\n", err)
 	}
 	for i, item := range status {
-		log.Printf("%s:\t%s\t%d\t%v\n", tags[i], item.Timestamp, item.Quality, item.Value)
+		if resultErrs[i] == nil {
+			log.Printf("%s:\t%s\t%d\t%v\n", tags[i], item.Timestamp, item.Quality, item.Value)
+		} else {
+			log.Printf("%s: error %v", tags[i], resultErrs[i])
+		}
 	}
 	// item read
 	log.Println("item read")
 	for i, item := range itemList {
 		value, quality, timestamp, err := item.Read(opcda.OPC_DS_CACHE)
 		if err != nil {
-			log.Fatalf("read item failed: %s\n", err)
+			log.Printf("%s: error %v\n", tags[i], err)
+		} else {
+			log.Printf("%s:\t%s\t%d\t%v\n", tags[i], timestamp, quality, value)
 		}
-		log.Printf("%s:\t%s\t%d\t%v\n", tags[i], timestamp, quality, value)
 	}
 }

--- a/opcgroup_test.go
+++ b/opcgroup_test.go
@@ -181,8 +181,10 @@ func TestOPCGroup_SyncRead(t *testing.T) {
 	item.SetIsActive(true)
 	for i := 0; i < 5; i++ {
 		time.Sleep(time.Second)
-		status, err := group.SyncRead(OPC_DS_CACHE, []uint32{item.GetServerHandle()})
+		status, resultErrs, err := group.SyncRead(OPC_DS_CACHE, []uint32{item.GetServerHandle()})
 		assert.NoError(t, err)
+		assert.Equal(t, 1, len(resultErrs))
+		assert.NoError(t, resultErrs[0])
 		t.Log(status[0])
 		assert.Equal(t, 1, len(status))
 		if status[0].Quality != uint16(192) {
@@ -216,8 +218,11 @@ func TestOPCGroup_ReadError(t *testing.T) {
 	assert.Equal(t, items, items2)
 	item, err := items.AddItem(TestReadErrorItem)
 	assert.NoError(t, err)
-	_, err = group.SyncRead(OPC_DS_CACHE, []uint32{item.GetServerHandle()})
-	assert.Error(t, err)
+	_, resultErrs, err := group.SyncRead(OPC_DS_CACHE, []uint32{item.GetServerHandle()})
+	// Read operation itself should succeed, but the individual read should fail
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(resultErrs))
+	assert.Error(t, resultErrs[0])
 }
 
 func TestOPCGroup_SyncWrite(t *testing.T) {


### PR DESCRIPTION
This PR updates the `SyncRead` method to return a list of errors, instead of failing completely if one of the item's reads fails. This brings it in line with the `AddItems` method, as well as the async read and write methods.

I've also updated the relevant example file and tested it on an OPC-DA server to verify it works as expected.